### PR TITLE
handle potential errors in quality encodings of Fastqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,19 @@
 
 ## Justification
 Controlled access (CA) data in Atlas can be processed depending on the datasets being:
-- Bulk
+- Bulk (gxa)
   - EGA/ENA - the code for EGA analysis is currently part of ISL, while the download parts are in their own repo: https://github.com/ebi-gene-expression-group/ega_downloader
-  - Non-EGA, such as [GTEx](https://gtexportal.org/home/datasets).
-- Single cell
+  - Non-EGA, such as [GTEx](https://gtexportal.org/home/datasets)
+- Single cell (scxa)
   - There’s also provision in the single-cell pipelines (currently unused) for single-cell CA data. Here’s some background on what was set up for single-cell: https://github.com/ebi-gene-expression-group/scxa-control-workflow/pull/16
   - An alternative path for ingesting data to SCXA would be via annData with our [atlas-anndata](https://github.com/ebi-gene-expression-group/atlas-anndata) tool. For instance, metadata has been extracted from annData in the GTEx portal under accession `E-ANND-2`.
 
 ## GTEx analysis
-The goal of this repo in to analyse bulk GTEx V8 data (study id: `E-GTEX-8`) with a Snakemake workflow to uncompress the bams and analyse on them fly. This can be done only by authorised users. 
+The goal of this repo in to analyse bulk GTEx V8 data (study id: `E-GTEX-8`) with a Snakemake workflow to uncompress the bams and analyse them on the fly. This can be done only by authorised users. 
 
 1. We want to keep same tools as in the standard Atlas RNA-seq pipeline with ISL/IRAP including QC steps to flag problematic samples, with special atention to delete Fastqs and intermediate files after successful procesing.
 
-2. Because we need to process 17350 libraries, the workflow should have constraint to enable batch processing of few libraries in parallel. 
+2. Because we need to process 17350 libraries, the workflow should have constraint to enable batch processing of few `n` libraries in parallel. 
 
 3. Input data is in BAM format
 
@@ -22,10 +22,8 @@ The goal of this repo in to analyse bulk GTEx V8 data (study id: `E-GTEX-8`) wit
 
 5. Once all libraries have been processed successfully, a final aggregation rule should write final results for E-GTEX-8 in a format similar to studies here `$IRAP_SINGLE_LIB/studies`.
 
-## Example
+### Example
 `snakemake -p --use-conda --conda-frontend conda --profile lsf --prioritize prepare_aggregation --keep-going --cores 4 --restart-times 5 --latency-wait 150 --config input_path=test-data atlas_gtex_root=/repo_directory_path/ private_script=gitlab_dir irap_config=homo_sapiens.conf`
-
-[LSF profile](https://github.com/Snakemake-Profiles/lsf) configuration is necessary.
 
 For batching, we can utilise the following batch command to run few samples at a time
 `snakemake -s Snakefile --cores 2 --batch final_workflow_check=n/N` where `N` is the total number of chunks, and `n=1,2, ..N`. 
@@ -33,5 +31,12 @@ For batching, we can utilise the following batch command to run few samples at a
 For instace, if we run the workflow in `N=347` batches, 50 libraries will be processed in each batch.
 
 
-## Test data
+### Test data
 At the moment some publicly available alignment (BAM) files are available in`test-data` directory. For further analysis of iRAP/ISL pipeline more data can be downloaded following [iRAP setup data](https://github.com/nunofonseca/irap/wiki/7-Quick-Example#setup-the-data) wiki.
+
+### Requirements
+- Snakemake 7.25.3 or higher
+- [LSF profile](https://github.com/Snakemake-Profiles/lsf) configuration
+- Two scripts located at the config `private_script`:
+  - gtex_bulk_env.sh
+  - gtex_bulk_init.sh

--- a/Snakefile
+++ b/Snakefile
@@ -269,7 +269,7 @@ rule run_irap_stage0:
         else
             # fastq is PE
             #split_fastq {input.fastq} $workingDir ${{localFastqPath}}
-            reformat.sh ow=t int=t vpair=t vint=t in={params.root_dir}/{input.fastq} out1=$workingDir/${{localFastqPath}}_1.fastq out2=$workingDir/${{localFastqPath}}_2.fastq
+            reformat.sh ow=t ibq=t int=t vpair=t vint=t in={params.root_dir}/{input.fastq} out1=$workingDir/${{localFastqPath}}_1.fastq out2=$workingDir/${{localFastqPath}}_2.fastq
             java -jar {params.root_dir}/scripts/validatefastq-assembly-0.1.1.jar --fastq1 $workingDir/${{localFastqPath}}_1.fastq --fastq2 $workingDir/${{localFastqPath}}_2.fastq
 
             echo "Calling irap_single_lib...PE mode"

--- a/Snakefile
+++ b/Snakefile
@@ -18,7 +18,7 @@ def get_mem_mb(wildcards, attempt):
     attemps = reiterations + 1
     Max number attemps = 6
     """
-    mem_avail = [ 8, 16, 32, 64, 128, 300 ]  
+    mem_avail = [ 12, 16, 32, 64, 128, 300 ]  
     if attempt > len(mem_avail):
         print(f"Attemps {attempt} exceeds the maximum number of attemps: {len(mem_avail)}")
         print(f"modify value of --restart-times or adjust mem_avail resources accordingly")
@@ -112,7 +112,8 @@ rule bam_to_fastq:
     log: "logs/{sample}/{sample}_bam_to_fastq.log"
     priority: 2
     resources: 
-        mem_mb=get_mem_mb
+        mem_mb=get_mem_mb,
+        disk_mb=70000
     shell:
         """
         set -e # snakemake on the cluster doesn't stop on error when --keep-going is set
@@ -200,7 +201,9 @@ rule run_irap_stage0:
     input:
         fastq= f"out/{FIRST_SAMPLE}/{FIRST_SAMPLE}.fq",
         check = f"out/{FIRST_SAMPLE}/{FIRST_SAMPLE}.fastq.val"
-    output: f"out/stage0_{FIRST_SAMPLE}.txt"
+    output:
+        completed = f"out/stage0_{FIRST_SAMPLE}.txt",
+        fastq_seqtk = temp(f"out/{FIRST_SAMPLE}/{FIRST_SAMPLE}.fq_seqtk")
     conda: "envs/isl.yaml"
     log: f"logs/irap_stage0_{FIRST_SAMPLE}.log"
     priority: 4
@@ -256,6 +259,21 @@ rule run_irap_stage0:
  
         pushd $workingDir > /dev/null
 	
+    	
+        # get quality enconding: 33 (sanger), 64 (illumina)
+        qual=$(testformat.sh {params.root_dir}/{input.fastq} | awk '{{print $1}}')
+        if [[ $qual == "sanger" ]]; then
+            qual_val="33"
+            maxcalledquality="93"
+            mincalledquality="0"
+        else
+            qual_val="64"
+            maxcalledquality="62"
+            mincalledquality="0"
+        fi
+        echo "quality enconding in fastq: $qual_val"
+        seqtk seq -q $mincalledquality -X $maxcalledquality -n N -C {params.root_dir}/{input.fastq} > {params.root_dir}/{input.fastq}_seqtk
+
         if [[ {params.read_type} == "se" ]]; then
             # fastq is SE
             cp {params.root_dir}/{input.fastq} $workingDir/${{localFastqPath}}.fastq
@@ -269,7 +287,7 @@ rule run_irap_stage0:
         else
             # fastq is PE
             #split_fastq {input.fastq} $workingDir ${{localFastqPath}}
-            reformat.sh ow=t ibq=t vint=t in={params.root_dir}/{input.fastq} out1=$workingDir/${{localFastqPath}}_1.fastq out2=$workingDir/${{localFastqPath}}_2.fastq
+            reformat.sh tossjunk=t tossbrokenreads=t changequality=t quantize=t mincalledquality=2 maxcalledquality=41 qin=$qual_val qout=$qual_val ow=t ibq=f vint=t in={params.root_dir}/{input.fastq}_seqtk out1=$workingDir/${{localFastqPath}}_1.fastq out2=$workingDir/${{localFastqPath}}_2.fastq
             java -jar {params.root_dir}/scripts/validatefastq-assembly-0.1.1.jar --fastq1 $workingDir/${{localFastqPath}}_1.fastq --fastq2 $workingDir/${{localFastqPath}}_2.fastq
 
             echo "Calling irap_single_lib...PE mode"
@@ -281,15 +299,17 @@ rule run_irap_stage0:
 
         popd
 
-        touch {output}
+        touch {output.completed}
         """
 
 rule run_irap:
     input:
         fastq=rules.bam_to_fastq.output.fastq,
         check = rules.validating_fastq.output.val_fastq,
-        stage0_completed=rules.run_irap_stage0.output
-    output: "out/{sample}/{sample}_irap_completed.done"
+        stage0_completed=rules.run_irap_stage0.output.completed
+    output:
+        completed = "out/{sample}/{sample}_irap_completed.done",
+        fastq_seqtk = temp("out/{sample}/{sample}.fq_seqtk")
     conda: "envs/isl.yaml"
     log: "logs/{sample}/{sample}_irap.log"
     priority: 4
@@ -347,6 +367,19 @@ rule run_irap:
 
         pushd $workingDir > /dev/null
 	
+        # get quality enconding: 33 (sanger), 64 (illumina)
+        qual=$(testformat.sh {params.root_dir}/{input.fastq} | awk '{{print $1}}')
+        if [[ $qual == "sanger" ]]; then
+            qual_val="33"
+            maxcalledquality="93"
+            mincalledquality="0"
+        else
+            qual_val="64"
+            maxcalledquality="62"
+            mincalledquality="0"
+        fi
+        echo "quality enconding in fastq: $qual_val"
+        seqtk seq -q $mincalledquality -X $maxcalledquality -n N -C {params.root_dir}/{input.fastq} > {params.root_dir}/{input.fastq}_seqtk
 
         if [[ {params.read_type} == "se" ]]; then
             # fastq is SE
@@ -360,10 +393,10 @@ rule run_irap:
             echo "irap_single_lib SE finished for {wildcards.sample}"
         else
             # fastq is PE
-            reformat.sh ow=t ibq=t vint=t in={params.root_dir}/{input.fastq} out1=$workingDir/${{localFastqPath}}_1.fastq out2=$workingDir/${{localFastqPath}}_2.fastq
+            reformat.sh tossjunk=t tossbrokenreads=t changequality=t quantize=t mincalledquality=2 maxcalledquality=41 qin=$qual_val qout=$qual_val ow=t ibq=f vint=t in={params.root_dir}/{input.fastq}_seqtk out1=$workingDir/${{localFastqPath}}_1.fastq out2=$workingDir/${{localFastqPath}}_2.fastq
             java -jar {params.root_dir}/scripts/validatefastq-assembly-0.1.1.jar --fastq1 $workingDir/${{localFastqPath}}_1.fastq --fastq2 $workingDir/${{localFastqPath}}_2.fastq
+
             echo "Calling irap_single_lib..."
-	    
             cmd="irap_single_lib -A -f -o irap_single_lib -1 ${{localFastqPath}}_1.fastq -2 ${{localFastqPath}}_2.fastq -c {params.conf} -s {params.strand} -m $irapMem -t {threads} -C {params.irapDataOption}"
             echo "PE IRAP will run now:"
             eval $cmd
@@ -373,7 +406,7 @@ rule run_irap:
         popd
 
         # The files to collected by aggregation from irap are in $IRAP_SINGLE_LIB/out
-        touch {output}
+        touch {output.completed}
         """
 
 
@@ -439,13 +472,11 @@ rule prepare_aggregation:
         touch {output}
         """
 
-
 #rule aggregate_libraries:
 #    """
 #    Final rule to agregate all library outputs, and store them in a single folder
 #    $IRAP_SINGLE_LIB/studies/E-GTEX-8/homo_sapiens/
 #    """
-
 
 rule final_workflow_check:
     input: expand(["out/{sample}/{sample}_prepare_aggregation.done"], sample=SAMPLES)

--- a/Snakefile
+++ b/Snakefile
@@ -269,7 +269,7 @@ rule run_irap_stage0:
         else
             # fastq is PE
             #split_fastq {input.fastq} $workingDir ${{localFastqPath}}
-            reformat.sh ow=t ibq=t int=t vpair=t vint=t in={params.root_dir}/{input.fastq} out1=$workingDir/${{localFastqPath}}_1.fastq out2=$workingDir/${{localFastqPath}}_2.fastq
+            reformat.sh ow=t ibq=t vint=t in={params.root_dir}/{input.fastq} out1=$workingDir/${{localFastqPath}}_1.fastq out2=$workingDir/${{localFastqPath}}_2.fastq
             java -jar {params.root_dir}/scripts/validatefastq-assembly-0.1.1.jar --fastq1 $workingDir/${{localFastqPath}}_1.fastq --fastq2 $workingDir/${{localFastqPath}}_2.fastq
 
             echo "Calling irap_single_lib...PE mode"
@@ -360,7 +360,7 @@ rule run_irap:
             echo "irap_single_lib SE finished for {wildcards.sample}"
         else
             # fastq is PE
-            reformat.sh ow=t ibq=t int=t vpair=t vint=t in={params.root_dir}/{input.fastq} out1=$workingDir/${{localFastqPath}}_1.fastq out2=$workingDir/${{localFastqPath}}_2.fastq
+            reformat.sh ow=t ibq=t vint=t in={params.root_dir}/{input.fastq} out1=$workingDir/${{localFastqPath}}_1.fastq out2=$workingDir/${{localFastqPath}}_2.fastq
             java -jar {params.root_dir}/scripts/validatefastq-assembly-0.1.1.jar --fastq1 $workingDir/${{localFastqPath}}_1.fastq --fastq2 $workingDir/${{localFastqPath}}_2.fastq
             echo "Calling irap_single_lib..."
 	    

--- a/Snakefile
+++ b/Snakefile
@@ -360,7 +360,7 @@ rule run_irap:
             echo "irap_single_lib SE finished for {wildcards.sample}"
         else
             # fastq is PE
-            reformat.sh ow=t int=t vpair=t vint=t in={params.root_dir}/{input.fastq} out1=$workingDir/${{localFastqPath}}_1.fastq out2=$workingDir/${{localFastqPath}}_2.fastq
+            reformat.sh ow=t ibq=t int=t vpair=t vint=t in={params.root_dir}/{input.fastq} out1=$workingDir/${{localFastqPath}}_1.fastq out2=$workingDir/${{localFastqPath}}_2.fastq
             java -jar {params.root_dir}/scripts/validatefastq-assembly-0.1.1.jar --fastq1 $workingDir/${{localFastqPath}}_1.fastq --fastq2 $workingDir/${{localFastqPath}}_2.fastq
             echo "Calling irap_single_lib..."
 	    

--- a/envs/isl.yaml
+++ b/envs/isl.yaml
@@ -8,6 +8,7 @@ dependencies:
   - bash
   - grep
   - fastq_utils
+  - seqtk
   - bbmap
   - java-jdk
   - atlas-bash-util>=0.1.1


### PR DESCRIPTION
- Add initial Fastq checks with `bbmap` and `seqtk` before running IRAP
- Fix out-of-range quality values instead of crashing with a warning
- edit the README file
